### PR TITLE
changed compression level to 16

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ impl ResourceSizeTable {
     pub fn to_binary(&self, compress: Option<bool>) -> Py<PyAny> {
         let mut data = self.0.to_binary();
         if compress.unwrap_or_default() {
-            data = zstd::encode_all(data.as_slice(), 15).unwrap();
+            data = zstd::encode_all(data.as_slice(), 16).unwrap();
         }
         Python::with_gil(|py| PyBytes::new(py, &data).into())
     }


### PR DESCRIPTION
Since using the package's compression didn't generate files that could be read by the game I've tried compressing the generated files with zstd in python and using level 16 generated working files. So I guess all you have to change in your code is the compression level.